### PR TITLE
Correctly humanize keystrokes using both shift and capital letters

### DIFF
--- a/spec/underscore-plus-spec.coffee
+++ b/spec/underscore-plus-spec.coffee
@@ -91,6 +91,9 @@ describe "underscore extensions", ->
       expect(_.humanizeKeystroke('cmd-|')).toEqual '⌘⇧\\'
       expect(_.humanizeKeystroke('cmd-}')).toEqual '⌘⇧]'
 
+    it "correctly replaces keystrokes with shift and capital letter", ->
+      expect(_.humanizeKeystroke('cmd-shift-P')).toEqual '⌘⇧P'
+
     it "replaces multiple keystrokes", ->
       expect(_.humanizeKeystroke('cmd-O cmd-n')).toEqual '⌘⇧O ⌘N'
 

--- a/src/underscore-plus.coffee
+++ b/src/underscore-plus.coffee
@@ -135,7 +135,7 @@ plus =
     for keystroke in keystrokes
       keys = keystroke.split('-')
       keys = _.flatten(plus.humanizeKey(key) for key in keys)
-      humanizedKeystrokes.push(keys.join(''))
+      humanizedKeystrokes.push(_.uniq(keys).join(''))
     humanizedKeystrokes.join(' ')
 
   isSubset: (potentialSubset, potentialSuperset) ->


### PR DESCRIPTION
Fixes https://github.com/atom/feedback/issues/27

Currently, keystrokes such as `cmd-shift-P` are humanized as `⌘⇧⇧P`, instead of as `⌘⇧P`:

![screen shot 2014-03-07 at 3 47 58 pm](https://f.cloud.github.com/assets/38924/2358097/84f02668-a607-11e3-937e-594eed93e4d2.png)

This pull request adds a test to detect the behavior, and fixes the issue by removing duplicate keys from a single humanized keystroke. 

Since keys in a keystroke should be unique, removing duplicates _should_ always be okay. Also, since keystrokes are normally short, the performance penalty of using `_.uniq` shouldn't be noticeable. 
