### PR TITLE
Added bower package manifest file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,29 @@
+{
+  "name": "underscore-plus",
+  "version": "1.3.0",
+  "homepage": "https://github.com/atom/underscore-plus",
+  "authors": [
+    "Kevin Sawicki <kevinsawicki@gmail.com>",
+    "Matt Colyer <matt@colyer.name>",
+    "benogle <ogle.ben@gmail.com>",
+    "nathansobo <nathan@github.com>"
+  ],
+  "description": "Underscore with some extensions",
+  "main": "./lib/underscore-plus.js",
+  "keywords": [
+    "underscore"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "spec",
+    "src",
+    "Gruntfile.coffee",
+    "package.json"
+  ],
+  "dependencies": {
+    "underscore": "1.x"
+  }
+}


### PR DESCRIPTION
As discussed in issue [here](https://twitter.com/kevinsawicki/status/473506122205126656) with @kevinsawicki, this PR contains the package manifest file for bower.

There are a couple of things to note. Bower works directly against the git repository, the bower repo itself does not contain any of the source itself. This means that which ever tag the bower package is pointing to needs to have the `lib` folder (or something similar) present.  

If committing `lib` to master isn't something you want to do, you can see what jquery does [here](https://github.com/jquery/jquery/tree/2.1.1). You will note that they only commit the `dist` folder to the "release" branch.

Instructions for registering the package can be found [here](http://bower.io/#registering-packages).
