### PR TITLE
Add _.deepContains(array, target)

### DIFF
--- a/spec/underscore-plus-spec.coffee
+++ b/spec/underscore-plus-spec.coffee
@@ -177,6 +177,19 @@ describe "underscore extensions", ->
             first: 1
             second: 2
 
+  describe "::deepContains(array, target)", ->
+    subject = null
+    beforeEach ->
+      subject = [{one: 1, two: {three: 3}}, {four: 4, five: {six: 6}}, 'omgkittens']
+
+    it "returns true for a matching object in the array", ->
+      expect(_.deepContains(subject, {four: 4, five: {six: 6}})).toBe true
+      expect(_.deepContains(subject, 'omgkittens')).toBe true
+
+    it "returns false when it does not find a match in the array", ->
+      expect(_.deepContains(subject, {four: 4, five: {six: 7}})).toBe false
+      expect(_.deepContains(subject, 'nope')).toBe false
+
   describe "::isSubset(potentialSubset, potentialSuperset)", ->
     it "returns whether the first argument is a subset of the second", ->
       expect(_.isSubset([1, 2], [1, 2])).toBeTruthy()

--- a/src/underscore-plus.coffee
+++ b/src/underscore-plus.coffee
@@ -100,6 +100,12 @@ plus =
 
     result
 
+  deepContains: (array, target) ->
+    return false unless array?
+    for object in array
+      return true if _.isEqual(object, target)
+    false
+
   endsWith: (string, suffix='') ->
     if string
       string.indexOf(suffix, string.length - suffix.length) isnt -1


### PR DESCRIPTION
Compares with `_.isEquals()` rather than `indexOf`.
