### PR TITLE
Handle null keypath in .valueForKeyPath

### DIFF
--- a/spec/underscore-plus-spec.coffee
+++ b/spec/underscore-plus-spec.coffee
@@ -304,6 +304,11 @@ describe "underscore extensions", ->
       expect(_.valueForKeyPath(object, 'a.b')).toEqual {'c\\.d': 2}
       expect(_.valueForKeyPath(object, 'a.x')).toBeUndefined()
 
+    it "returns the object when no key path is given", ->
+      object = {a: b: 'c\\.d': 2}
+      expect(_.valueForKeyPath(object, null)).toBe(object)
+      expect(_.valueForKeyPath(object)).toBe(object)
+
   describe "::setValueForKeyPath(object, keyPath, value)", ->
     it "assigns a value at the given key path, creating intermediate objects if needed", ->
       object = {}

--- a/src/underscore-plus.coffee
+++ b/src/underscore-plus.coffee
@@ -42,6 +42,7 @@ shiftKeyMap =
 splitKeyPath = (keyPath) ->
   startIndex = 0
   keyPathArray = []
+  return keyPathArray unless keyPath?
   for char, i in keyPath
     if char is '.' and (i is 0 or keyPath[i-1] != '\\')
       keyPathArray.push keyPath.substring(startIndex, i)


### PR DESCRIPTION
``` coffee
_.valueForKeyPath(object, null) is object
```

This is to make atom's [`Config::get`](https://github.com/atom/atom/blob/master/src/config.coffee#L458) consistent with [`::observe`](https://github.com/atom/atom/blob/master/src/config.coffee#L351), in that a null/undefined `keyPath` corresponds to the entire object.
