### PR TITLE
Don't iterate over prototype's keys in .mapObject

### DIFF
--- a/dist/underscore-plus.js
+++ b/dist/underscore-plus.js
@@ -282,6 +282,9 @@
       newObject = {};
       for (key in object) {
         value = object[key];
+        if (!object.hasOwnProperty(key)) {
+          continue;
+        }
         _ref = iterator(key, value), key = _ref[0], value = _ref[1];
         newObject[key] = value;
       }

--- a/src/underscore-plus.coffee
+++ b/src/underscore-plus.coffee
@@ -217,6 +217,7 @@ plus =
   mapObject: (object, iterator) ->
     newObject = {}
     for key, value of object
+      continue unless object.hasOwnProperty(key)
       [key, value] = iterator(key, value)
       newObject[key] = value
 


### PR DESCRIPTION
This is also related to the performance regression noticed in atom/atom#4666.
