### PR TITLE
Bump Underscore to v1.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "underscore"
   ],
   "dependencies": {
-    "underscore": "~1.6.0"
+    "underscore": "~1.8.3"
   },
   "devDependencies": {
     "jasmine-focused": "1.x",


### PR DESCRIPTION
There have been breaking changes made to Underscore since v1.6.0, so if we merge this we should release this as a major release.

Since v1.6.0 there have been some really useful additions and bugfixes, but ultimately I'm not sure if this is worth it. Was hoping to use some of the additions as part of https://github.com/atom/atom/pull/7877, but I can find other solutions.

/cc @atom/feedback 