### PR TITLE
Don't put backslashes before dashes in escapeRegExp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ notifications:
     on_failure: change
 
 node_js:
-  - 0.10
+  - 8

--- a/dist/underscore-plus.js
+++ b/dist/underscore-plus.js
@@ -186,7 +186,7 @@
     },
     escapeRegExp: function(string) {
       if (string) {
-        return string.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+        return string.replace(/[\/\\^$*+?.()|[\]{}]/g, '\\$&');
       } else {
         return '';
       }

--- a/spec/underscore-plus-spec.coffee
+++ b/spec/underscore-plus-spec.coffee
@@ -370,3 +370,25 @@ describe "underscore extensions", ->
           f: [4, 'abc']
 
       expect(_.deepClone(object)).toEqual object
+
+  describe "::escapeRegExp(string)", ->
+    it "returns a regular expression pattern that can will match the given string", ->
+      check = (source) ->
+        regex = new RegExp(_.escapeRegExp(source))
+        expect(source.match(regex)[0]).toBe(source)
+
+        regex = new RegExp(_.escapeRegExp(source), 'u')
+        expect(source.match(regex)[0]).toBe(source)
+
+      check('ab')
+      check('a[b')
+      check('a]b')
+      check('a(b')
+      check('a)b')
+      check('a-b')
+      check('[a-b]')
+      check('a{2}b{3}')
+      check('a|b')
+      check('([a-b])')
+      check('a?b?')
+      check('a...b...')

--- a/src/underscore-plus.coffee
+++ b/src/underscore-plus.coffee
@@ -135,7 +135,7 @@ plus =
 
   escapeRegExp: (string) ->
     if string
-      string.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
+      string.replace(/[\/\\^$*+?.()|[\]{}]/g, '\\$&')
     else
       ''
 


### PR DESCRIPTION
Previously, the `escapeRegExp` function would insert backslashes before any dashes in the given string. This was basically a noop, but didn't cause any problems. When constructing a `RegExp` with the `u` (unicode) flag, this becomes a `SyntaxError`.

This PR removes `-` from the list of characters that we need to escape. It also backfills tests for `escapeRegExp`.

Fixes atom/find-and-replace#1022